### PR TITLE
Fix race condition when reloading new configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.sw[op]
 .DS_Store
+.idea

--- a/config.go
+++ b/config.go
@@ -31,6 +31,8 @@ type xmlLoggerConfig struct {
 // Load XML configuration; see examples/example.xml for documentation
 func (log Logger) LoadConfiguration(filename string) {
 	log.Close()
+	log.acquireWriteLock()
+	defer log.releaseWriteLock()
 
 	// Open the configuration file
 	fd, err := os.Open(filename)
@@ -126,7 +128,7 @@ func (log Logger) LoadConfiguration(filename string) {
 			continue
 		}
 
-		log[xmlfilt.Tag] = &Filter{lvl, filt}
+		log.Filters[xmlfilt.Tag] = &Filter{lvl, filt}
 	}
 }
 

--- a/filelog.go
+++ b/filelog.go
@@ -13,6 +13,8 @@ type FileLogWriter struct {
 	rec chan *LogRecord
 	rot chan bool
 
+	closed bool
+
 	// The opened file
 	filename string
 	file     *os.File
@@ -42,10 +44,13 @@ type FileLogWriter struct {
 
 // This is the FileLogWriter's output method
 func (w *FileLogWriter) LogWrite(rec *LogRecord) {
-	w.rec <- rec
+	if !w.closed {
+		w.rec <- rec
+	}
 }
 
 func (w *FileLogWriter) Close() {
+	w.closed = true
 	close(w.rec)
 	w.file.Sync()
 }

--- a/log4go.go
+++ b/log4go.go
@@ -52,6 +52,7 @@ import (
 	"runtime"
 	"strings"
 	"time"
+	"sync"
 )
 
 // Version information
@@ -128,70 +129,117 @@ type Filter struct {
 	LogWriter
 }
 
+type Filters map[string]*Filter
+
 // A Logger represents a collection of Filters through which log messages are
 // written.
-type Logger map[string]*Filter
+type Logger struct {
+	Filters
+	sync.RWMutex
+}
+
+func (log *Logger) acquireLock() {
+	log.RLock()
+}
+
+func (log *Logger) releaseLock() {
+	log.RUnlock()
+}
+
+func (log *Logger) acquireWriteLock() {
+	log.Lock()
+}
+
+func (log *Logger) releaseWriteLock() {
+	log.Unlock()
+}
 
 // Create a new logger.
-//
-// DEPRECATED: Use make(Logger) instead.
-func NewLogger() Logger {
-	os.Stderr.WriteString("warning: use of deprecated NewLogger\n")
-	return make(Logger)
+func NewLogger() *Logger {
+	return &Logger{Filters: make(Filters), RWMutex: sync.RWMutex{}}
 }
 
 // Create a new logger with a "stdout" filter configured to send log messages at
 // or above lvl to standard output.
 //
 // DEPRECATED: use NewDefaultLogger instead.
-func NewConsoleLogger(lvl Level) Logger {
+func NewConsoleLogger(lvl Level) *Logger {
 	os.Stderr.WriteString("warning: use of deprecated NewConsoleLogger\n")
-	return Logger{
-		"stdout": &Filter{lvl, NewConsoleLogWriter()},
-	}
+	return NewDefaultLogger(lvl)
 }
 
 // Create a new logger with a "stdout" filter configured to send log messages at
 // or above lvl to standard output.
-func NewDefaultLogger(lvl Level) Logger {
-	return Logger{
-		"stdout": &Filter{lvl, NewConsoleLogWriter()},
-	}
+func NewDefaultLogger(lvl Level) *Logger {
+	logger := NewLogger()
+	logger.Filters["stdout"] = &Filter{lvl, NewConsoleLogWriter()}
+	return logger
 }
 
 // Closes all log writers in preparation for exiting the program or a
 // reconfiguration of logging.  Calling this is not really imperative, unless
 // you want to guarantee that all log messages are written.  Close removes
 // all filters (and thus all LogWriters) from the logger.
-func (log Logger) Close() {
+func (log *Logger) Close() {
+	log.acquireWriteLock()
+	defer log.releaseWriteLock()
+
 	// Close all open loggers
-	for name, filt := range log {
+	for name, filt := range log.Filters {
 		filt.Close()
-		delete(log, name)
+		delete(log.Filters, name)
 	}
 }
 
 // Add a new LogWriter to the Logger which will only log messages at lvl or
 // higher.  This function should not be called from multiple goroutines.
 // Returns the logger for chaining.
-func (log Logger) AddFilter(name string, lvl Level, writer LogWriter) Logger {
-	log[name] = &Filter{lvl, writer}
+func (log *Logger) AddFilter(name string, lvl Level, writer LogWriter) *Logger {
+	log.Filters[name] = &Filter{lvl, writer}
 	return log
 }
 
-/******* Logging *******/
-// Send a formatted log message internally
-func (log Logger) intLogf(lvl Level, format string, args ...interface{}) {
-	skip := true
-
+func (log *Logger) shouldSkip(lvl Level) bool {
 	// Determine if any logging will be done
-	for _, filt := range log {
+	skip := true
+	for _, filt := range log.Filters {
 		if lvl >= filt.Level {
 			skip = false
 			break
 		}
 	}
-	if skip {
+
+	return skip
+}
+
+func (log *Logger) dispatchLogsForLogRecord(lvl Level, rec *LogRecord) {
+	// Dispatch the logs
+	for _, filt := range log.Filters {
+		if lvl < filt.Level {
+			continue
+		}
+		filt.LogWrite(rec)
+	}
+}
+
+func (log *Logger) dispatchLogsForSourceAndMessage(lvl Level, source, message string) {
+	// Make the log record
+	rec := &LogRecord{
+		Level:   lvl,
+		Created: time.Now(),
+		Source:  source,
+		Message: message,
+	}
+
+	log.dispatchLogsForLogRecord(lvl, rec)
+}
+
+/******* Logging *******/
+// Send a formatted log message internally
+func (log *Logger) intLogf(lvl Level, format string, args ...interface{}) {
+	log.acquireLock()
+	defer log.releaseLock()
+	if log.shouldSkip(lvl) {
 		return
 	}
 
@@ -207,35 +255,14 @@ func (log Logger) intLogf(lvl Level, format string, args ...interface{}) {
 		msg = fmt.Sprintf(format, args...)
 	}
 
-	// Make the log record
-	rec := &LogRecord{
-		Level:   lvl,
-		Created: time.Now(),
-		Source:  src,
-		Message: msg,
-	}
-
-	// Dispatch the logs
-	for _, filt := range log {
-		if lvl < filt.Level {
-			continue
-		}
-		filt.LogWrite(rec)
-	}
+	log.dispatchLogsForSourceAndMessage(lvl, src, msg)
 }
 
 // Send a closure log message internally
-func (log Logger) intLogc(lvl Level, closure func() string) {
-	skip := true
-
-	// Determine if any logging will be done
-	for _, filt := range log {
-		if lvl >= filt.Level {
-			skip = false
-			break
-		}
-	}
-	if skip {
+func (log *Logger) intLogc(lvl Level, closure func() string) {
+	log.acquireLock()
+	defer log.releaseLock()
+	if log.shouldSkip(lvl) {
 		return
 	}
 
@@ -246,103 +273,58 @@ func (log Logger) intLogc(lvl Level, closure func() string) {
 		src = fmt.Sprintf("%s:%d", runtime.FuncForPC(pc).Name(), lineno)
 	}
 
-	// Make the log record
-	rec := &LogRecord{
-		Level:   lvl,
-		Created: time.Now(),
-		Source:  src,
-		Message: closure(),
-	}
-
-	// Dispatch the logs
-	for _, filt := range log {
-		if lvl < filt.Level {
-			continue
-		}
-		filt.LogWrite(rec)
-	}
+	log.dispatchLogsForSourceAndMessage(lvl, src, closure())
 }
 
 // Send a log message with manual level, source, and message.
-func (log Logger) Log(lvl Level, source, message string) {
-	skip := true
-
-	// Determine if any logging will be done
-	for _, filt := range log {
-		if lvl >= filt.Level {
-			skip = false
-			break
-		}
-	}
-	if skip {
+func (log *Logger) Log(lvl Level, source, message string) {
+	log.acquireLock()
+	defer log.releaseLock()
+	if log.shouldSkip(lvl) {
 		return
 	}
 
-	// Make the log record
-	rec := &LogRecord{
-		Level:   lvl,
-		Created: time.Now(),
-		Source:  source,
-		Message: message,
-	}
-
-	// Dispatch the logs
-	for _, filt := range log {
-		if lvl < filt.Level {
-			continue
-		}
-		filt.LogWrite(rec)
-	}
+	log.dispatchLogsForSourceAndMessage(lvl, source, message)
 }
 
 // Logf logs a formatted log message at the given log level, using the caller as
 // its source.
-func (log Logger) Logf(lvl Level, format string, args ...interface{}) {
+func (log *Logger) Logf(lvl Level, format string, args ...interface{}) {
 	log.intLogf(lvl, format, args...)
 }
 
 // Logc logs a string returned by the closure at the given log level, using the caller as
 // its source.  If no log message would be written, the closure is never called.
-func (log Logger) Logc(lvl Level, closure func() string) {
+func (log *Logger) Logc(lvl Level, closure func() string) {
 	log.intLogc(lvl, closure)
+}
+
+func (log *Logger) upToInfo(lvl Level, arg0 interface{}, args ...interface{}) {
+	switch first := arg0.(type) {
+	case string:
+		// Use the string as a format string
+		log.intLogf(lvl, first, args...)
+	case func() string:
+		// Log the closure (no other arguments used)
+		log.intLogc(lvl, first)
+	default:
+		// Build a format string so that it will be similar to Sprint
+		log.intLogf(lvl, fmt.Sprint(arg0)+strings.Repeat(" %v", len(args)), args...)
+	}
 }
 
 // Finest logs a message at the finest log level.
 // See Debug for an explanation of the arguments.
-func (log Logger) Finest(arg0 interface{}, args ...interface{}) {
-	const (
-		lvl = FINEST
-	)
-	switch first := arg0.(type) {
-	case string:
-		// Use the string as a format string
-		log.intLogf(lvl, first, args...)
-	case func() string:
-		// Log the closure (no other arguments used)
-		log.intLogc(lvl, first)
-	default:
-		// Build a format string so that it will be similar to Sprint
-		log.intLogf(lvl, fmt.Sprint(arg0)+strings.Repeat(" %v", len(args)), args...)
-	}
+func (log *Logger) Finest(arg0 interface{}, args ...interface{}) {
+	const lvl = FINEST
+	log.upToInfo(lvl, arg0, args...)
 }
 
 // Fine logs a message at the fine log level.
 // See Debug for an explanation of the arguments.
-func (log Logger) Fine(arg0 interface{}, args ...interface{}) {
-	const (
-		lvl = FINE
-	)
-	switch first := arg0.(type) {
-	case string:
-		// Use the string as a format string
-		log.intLogf(lvl, first, args...)
-	case func() string:
-		// Log the closure (no other arguments used)
-		log.intLogc(lvl, first)
-	default:
-		// Build a format string so that it will be similar to Sprint
-		log.intLogf(lvl, fmt.Sprint(arg0)+strings.Repeat(" %v", len(args)), args...)
-	}
+func (log *Logger) Fine(arg0 interface{}, args ...interface{}) {
+	const lvl = FINE
+	log.upToInfo(lvl, arg0, args...)
 }
 
 // Debug is a utility method for debug log messages.
@@ -357,59 +339,40 @@ func (log Logger) Fine(arg0 interface{}, args ...interface{}) {
 // - arg0 is interface{}
 //   When given anything else, the log message will be each of the arguments
 //   formatted with %v and separated by spaces (ala Sprint).
-func (log Logger) Debug(arg0 interface{}, args ...interface{}) {
-	const (
-		lvl = DEBUG
-	)
-	switch first := arg0.(type) {
-	case string:
-		// Use the string as a format string
-		log.intLogf(lvl, first, args...)
-	case func() string:
-		// Log the closure (no other arguments used)
-		log.intLogc(lvl, first)
-	default:
-		// Build a format string so that it will be similar to Sprint
-		log.intLogf(lvl, fmt.Sprint(arg0)+strings.Repeat(" %v", len(args)), args...)
-	}
+func (log *Logger) Debug(arg0 interface{}, args ...interface{}) {
+	const lvl = DEBUG
+	log.upToInfo(lvl, arg0, args...)
 }
 
 // Trace logs a message at the trace log level.
 // See Debug for an explanation of the arguments.
-func (log Logger) Trace(arg0 interface{}, args ...interface{}) {
-	const (
-		lvl = TRACE
-	)
-	switch first := arg0.(type) {
-	case string:
-		// Use the string as a format string
-		log.intLogf(lvl, first, args...)
-	case func() string:
-		// Log the closure (no other arguments used)
-		log.intLogc(lvl, first)
-	default:
-		// Build a format string so that it will be similar to Sprint
-		log.intLogf(lvl, fmt.Sprint(arg0)+strings.Repeat(" %v", len(args)), args...)
-	}
+func (log *Logger) Trace(arg0 interface{}, args ...interface{}) {
+	const lvl = TRACE
+	log.upToInfo(lvl, arg0, args...)
 }
 
 // Info logs a message at the info log level.
 // See Debug for an explanation of the arguments.
-func (log Logger) Info(arg0 interface{}, args ...interface{}) {
-	const (
-		lvl = INFO
-	)
+func (log *Logger) Info(arg0 interface{}, args ...interface{}) {
+	const lvl = INFO
+	log.upToInfo(lvl, arg0, args...)
+}
+
+func (log *Logger) overWarning(lvl Level, arg0 interface{}, args ...interface{}) error {
+	var msg string
 	switch first := arg0.(type) {
 	case string:
 		// Use the string as a format string
-		log.intLogf(lvl, first, args...)
+		msg = fmt.Sprintf(first, args...)
 	case func() string:
 		// Log the closure (no other arguments used)
-		log.intLogc(lvl, first)
+		msg = first()
 	default:
 		// Build a format string so that it will be similar to Sprint
-		log.intLogf(lvl, fmt.Sprint(arg0)+strings.Repeat(" %v", len(args)), args...)
+		msg = fmt.Sprintf(fmt.Sprint(first)+strings.Repeat(" %v", len(args)), args...)
 	}
+	log.intLogf(lvl, msg)
+	return errors.New(msg)
 }
 
 // Warn logs a message at the warning log level and returns the formatted error.
@@ -417,68 +380,23 @@ func (log Logger) Info(arg0 interface{}, args ...interface{}) {
 // message is not actually logged, because all formats are processed and all
 // closures are executed to format the error message.
 // See Debug for further explanation of the arguments.
-func (log Logger) Warn(arg0 interface{}, args ...interface{}) error {
-	const (
-		lvl = WARNING
-	)
-	var msg string
-	switch first := arg0.(type) {
-	case string:
-		// Use the string as a format string
-		msg = fmt.Sprintf(first, args...)
-	case func() string:
-		// Log the closure (no other arguments used)
-		msg = first()
-	default:
-		// Build a format string so that it will be similar to Sprint
-		msg = fmt.Sprintf(fmt.Sprint(first)+strings.Repeat(" %v", len(args)), args...)
-	}
-	log.intLogf(lvl, msg)
-	return errors.New(msg)
+func (log *Logger) Warn(arg0 interface{}, args ...interface{}) error {
+	const lvl = WARNING
+	return log.overWarning(lvl, arg0, args...)
 }
 
 // Error logs a message at the error log level and returns the formatted error,
 // See Warn for an explanation of the performance and Debug for an explanation
 // of the parameters.
-func (log Logger) Error(arg0 interface{}, args ...interface{}) error {
-	const (
-		lvl = ERROR
-	)
-	var msg string
-	switch first := arg0.(type) {
-	case string:
-		// Use the string as a format string
-		msg = fmt.Sprintf(first, args...)
-	case func() string:
-		// Log the closure (no other arguments used)
-		msg = first()
-	default:
-		// Build a format string so that it will be similar to Sprint
-		msg = fmt.Sprintf(fmt.Sprint(first)+strings.Repeat(" %v", len(args)), args...)
-	}
-	log.intLogf(lvl, msg)
-	return errors.New(msg)
+func (log *Logger) Error(arg0 interface{}, args ...interface{}) error {
+	const lvl = ERROR
+	return log.overWarning(lvl, arg0, args...)
 }
 
 // Critical logs a message at the critical log level and returns the formatted error,
 // See Warn for an explanation of the performance and Debug for an explanation
 // of the parameters.
-func (log Logger) Critical(arg0 interface{}, args ...interface{}) error {
-	const (
-		lvl = CRITICAL
-	)
-	var msg string
-	switch first := arg0.(type) {
-	case string:
-		// Use the string as a format string
-		msg = fmt.Sprintf(first, args...)
-	case func() string:
-		// Log the closure (no other arguments used)
-		msg = first()
-	default:
-		// Build a format string so that it will be similar to Sprint
-		msg = fmt.Sprintf(fmt.Sprint(first)+strings.Repeat(" %v", len(args)), args...)
-	}
-	log.intLogf(lvl, msg)
-	return errors.New(msg)
+func (log *Logger) Critical(arg0 interface{}, args ...interface{}) error {
+	const lvl = CRITICAL
+	return log.overWarning(lvl, arg0, args...)
 }

--- a/termlog.go
+++ b/termlog.go
@@ -15,6 +15,7 @@ var stdout io.Writer = os.Stdout
 type ConsoleLogWriter struct {
 	format string
 	w      chan *LogRecord
+	closed bool
 }
 
 // This creates a new ConsoleLogWriter
@@ -38,12 +39,15 @@ func (c *ConsoleLogWriter) run(out io.Writer) {
 // This is the ConsoleLogWriter's output method.  This will block if the output
 // buffer is full.
 func (c *ConsoleLogWriter) LogWrite(rec *LogRecord) {
-	c.w <- rec
+	if !c.closed {
+		c.w <- rec
+	}
 }
 
 // Close stops the logger from sending messages to standard output.  Attempts to
 // send log messages to this logger after a Close have undefined behavior.
 func (c *ConsoleLogWriter) Close() {
+	c.closed = true
 	close(c.w)
 	time.Sleep(50 * time.Millisecond) // Try to give console I/O time to complete
 }

--- a/wrapper.go
+++ b/wrapper.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	Global Logger
+	Global *Logger
 )
 
 func init() {


### PR DESCRIPTION
Breaking changes: 
* Need to call `NewLogger()` instead of `make(Logger)`
* `NewLogger()` returns pointer
* Direct access to the filters in `Logger` should be addressed as `log.Filters` now

@chenkjfrog 